### PR TITLE
fix(iOS): missing country translation

### DIFF
--- a/src/ios/GoogleMaps/PluginGeocoder.m
+++ b/src/ios/GoogleMaps/PluginGeocoder.m
@@ -29,7 +29,16 @@
   {
       NSString *identifier = [NSLocale localeIdentifierFromComponents: [NSDictionary dictionaryWithObject: countryCode forKey: NSLocaleCountryCode]];
       NSString *country = [[[NSLocale alloc] initWithLocaleIdentifier:currentLanguage] displayNameForKey: NSLocaleIdentifier value: identifier];
-      [countries addObject: country];
+      if (country != nil) {
+          [countries addObject: country];
+      } else {
+          NSString *countryFallback = [[[NSLocale alloc] initWithLocaleIdentifier:@"en-US"] displayNameForKey: NSLocaleIdentifier value: identifier];
+          if (countryFallback != nil) {
+              [countries addObject: countryFallback];
+          } else {
+              [countries addObject: countryCode];
+          }
+      }
   }
 
   self.codeForCountryDictionary = [[NSDictionary alloc] initWithObjects:countryCodes forKeys:countries];


### PR DESCRIPTION
On iOS 17.4, some country (CQ) translation was missing for some languages which crashed the app (nil ref).

This PR implements a check for nil values as well as a fallback on en-US translations. If all else fails, the countryCode string is used